### PR TITLE
Add SYSV init script to the deb package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,10 @@ FPM_OPTS := -s dir -n chronos -v $(PKG_VER) --iteration $(PKG_REL) \
 	--maintainer "Mesosphere Package Builder <support@mesosphere.io>" \
 	--vendor "Mesosphere, Inc."
 FPM_OPTS_DEB := -t deb --config-files etc/ \
-	-d 'java7-runtime-headless | java6-runtime-headless'
+	-d 'java7-runtime-headless | java6-runtime-headless' \
+	--deb-init chronos.init \
+	--after-install chronos.postinst \
+	--after-remove chronos.postrm
 FPM_OPTS_RPM := -t rpm --config-files etc/ \
 	-d coreutils -d 'java >= 1.6'
 FPM_OPTS_OSX := -t osxpkg --osxpkg-identifier-prefix io.mesosphere
@@ -51,7 +54,10 @@ fedora: toor/fedora/etc/chronos/conf/http_port
 
 .PHONY: deb
 deb: toor/deb/etc/init/chronos.conf
+deb: toor/deb/etc/init.d/chronos
 deb: toor/deb/$(PREFIX)/bin/chronos
+deb: chronos.postinst
+deb: chronos.postrm
 deb: toor/deb/etc/chronos/conf/http_port
 	fpm -C toor/deb $(FPM_OPTS_DEB) $(FPM_OPTS) .
 
@@ -62,6 +68,10 @@ osx: toor/osx/$(PREFIX)/bin/chronos
 toor/%/etc/init/chronos.conf: chronos.conf
 	mkdir -p "$(dir $@)"
 	cp chronos.conf "$@"
+
+toor/%/etc/init.d/chronos: chronos.init
+	mkdir -p "$(dir $@)"
+	cp chronos.init "$@"
 
 toor/%/usr/lib/systemd/system/chronos.service: chronos.service
 	mkdir -p "$(dir $@)"

--- a/chronos.init
+++ b/chronos.init
@@ -1,0 +1,56 @@
+#!/bin/bash
+### BEGIN INIT INFO
+# Provides:          chronos
+# Required-Start:    $local_fs $remote_fs $network $syslog
+# Required-Stop:     $local_fs $remote_fs $network $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Init for Apache Mesos
+# Description:       Cluster-wide init and control system for Apache Mesos
+### END INIT INFO
+set -ue
+
+NAME="chronos"
+DESC="chronos"
+
+. /lib/lsb/init-functions
+
+PID=/var/run/chronos.pid
+
+start() {
+  start-stop-daemon --start --background --quiet \
+                    --pidfile "$PID" --make-pidfile \
+                    --exec /usr/local/bin/chronos
+}
+
+stop() {
+  start-stop-daemon --stop --quiet --pidfile "$PID"
+}
+
+case "${1-}" in
+  start)
+    echo -n "Starting $DESC: "
+    start
+    echo "$NAME."
+    ;;
+  stop)
+    echo -n "Stopping $DESC: "
+    stop
+    echo "$NAME."
+    ;;
+  restart)
+    echo -n "Restarting $DESC: "
+    stop
+    sleep 1
+    start
+    echo "$NAME."
+    ;;
+  status)
+    status_of_proc -p "$PID" "$NAME" "$NAME"
+    ;;
+  *)
+    echo "Usage: $0 {start|stop|restart|status}" >&2
+    exit 1
+    ;;
+esac
+

--- a/chronos.postinst
+++ b/chronos.postinst
@@ -1,0 +1,30 @@
+#!/bin/sh
+set -e
+
+codename () {
+  out $(lsb_release -cs)
+}
+
+out () { printf '%s\n' "$*" ;}
+
+case "$1" in
+
+  configure)
+    if [ "$(codename)" = "wheezy" ]; then
+      # Enable the SYSV links (only used on select systems).
+      update-rc.d chronos defaults
+    fi
+    ;;
+
+  configure|abort-upgrade|abort-remove|abort-deconfigure)
+    ;;
+
+  *)
+    echo "postinst called with unknown argument \`$1'" >&2
+    exit 1
+    ;;
+esac
+
+#DEBHELPER#
+
+exit 0

--- a/chronos.postrm
+++ b/chronos.postrm
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -e
+
+codename () {
+  out $(lsb_release -cs)
+}
+
+out () { printf '%s\n' "$*" ;}
+
+case "$1" in
+  purge)
+    if [ "$(codename)" = "wheezy" ]; then
+      # Disable the SYSV links (only used on select systems).
+      update-rc.d chronos remove
+    fi
+    ;;
+
+  remove|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
+    ;;
+
+  *)
+    echo "postrm called with unknown argument \`$1'" >&2
+    exit 1
+    ;;
+esac
+
+#DEBHELPER#
+
+exit 0


### PR DESCRIPTION
This is useful for debian wheezy which does not have upstart support.
The approach taken was similar to that used by the marathon package in
the following: mesosphere/marathon-pkg@877daf16a6e7719d78bce68c9459a1094f23f99c
