### PR TITLE
CLI args take precedence over local configuration files

### DIFF
--- a/bin/chronos-framework
+++ b/bin/chronos-framework
@@ -28,6 +28,12 @@ function main {
   load_options_and_log "$@"
 }
 
+function element_in {
+  local e
+  for e in "${@:2}"; do [[ "$e" == "$1" ]] && return 0; done
+  return 1
+}
+
 function load_options_and_log {
   set -x
   # Load Chronos options from Mesos and Chronos conf files that are present.
@@ -43,10 +49,13 @@ function load_options_and_log {
     while read -u 9 -r -d '' path
     do
       local name="${path#./}"
-      case "$name" in
-        '?'*) cmd+=( "--${name#'?'}" ) ;;
-        *)    cmd+=( "--$name" "$(cat "$conf_dir/$name")" ) ;;
-      esac
+      if ! element_in "--${name}" "$@"
+      then
+        case "$name" in
+          '?'*) cmd+=( "--${name#'?'}" ) ;;
+          *)    cmd+=( "--$name" "$(< "$conf_dir/$name")" ) ;;
+        esac
+      fi
     done 9< <(cd "$conf_dir" && find . -type f -not -name '.*' -print0)
   fi
   logged chronos "${cmd[@]}" "$@"


### PR DESCRIPTION
There was a problem if using a command line argument when a local configuration file is present already. The option was interpreted twice. This fix also applies to mesos and marathon startup scripts.
