### PR TITLE
Allowing optional JVM parameters to be set

### DIFF
--- a/bin/chronos-framework
+++ b/bin/chronos-framework
@@ -65,9 +65,11 @@ function run_jar {
   local log_format='%2$s %5$s%6$s%n' # Class name, message, exception
   ulimit -n 8192
   export PATH=/usr/local/bin:"$PATH"
-  local vm_opts=( -Xmx512m
-                  -Djava.library.path=/usr/local/lib:/usr/lib64:/usr/lib
+  local vm_opts=( -Djava.library.path=/usr/local/lib:/usr/lib64:/usr/lib
                   -Djava.util.logging.SimpleFormatter.format="$log_format" )
+  for j_opt in ${JAVA_OPTS:-"-Xmx512m"}; do
+    vm_opts+=( ${j_opt} )
+  done
   # TODO: Set main class in pom.xml and use -jar
   exec java "${vm_opts[@]}" -cp "$chronos_jar" org.apache.mesos.chronos.scheduler.Main "$@"
 }

--- a/chronos.service
+++ b/chronos.service
@@ -4,6 +4,7 @@ After=network.target
 Wants=network.target
 
 [Service]
+EnvironmentFile=-/etc/sysconfig/chronos
 ExecStart=/usr/bin/chronos
 Restart=always
 RestartSec=20


### PR DESCRIPTION
We have a need to set some custom JVM parameters on the Chronos process (for logging configuration, etc.), so it would be nice to be able to set these in the init script rather than having to patch the /usr/bin/chronos script.  