### PR TITLE
Update chronos-framework wrapper with current marathon-framework fixes

### DIFF
--- a/bin/chronos-framework
+++ b/bin/chronos-framework
@@ -65,9 +65,11 @@ function run_jar {
   local log_format='%2$s %5$s%6$s%n' # Class name, message, exception
   ulimit -n 8192
   export PATH=/usr/local/bin:"$PATH"
-  local vm_opts=( -Xmx512m
-                  -Djava.library.path=/usr/local/lib:/usr/lib64:/usr/lib
+  local vm_opts=( -Djava.library.path=/usr/local/lib:/usr/lib64:/usr/lib
                   -Djava.util.logging.SimpleFormatter.format="$log_format" )
+  for j_opt in ${JAVA_OPTS:-"-Xmx512m"}; do
+    vm_opts+=( ${j_opt} )
+  done
   # TODO: Set main class in pom.xml and use -jar
   exec java "${vm_opts[@]}" -cp "$chronos_jar" org.apache.mesos.chronos.scheduler.Main "$@"
 }

--- a/bin/chronos-framework
+++ b/bin/chronos-framework
@@ -63,7 +63,10 @@ function load_options_and_log {
 
 function run_jar {
   local log_format='%2$s %5$s%6$s%n' # Class name, message, exception
-  ulimit -n 8192
+
+  # if running as root and open file limit less than 8192 raise the limit
+  [ $EUID -eq 0 -a $(ulimit -n) -lt 8192 ] && ulimit -n 8192
+
   export PATH=/usr/local/bin:"$PATH"
   local vm_opts=( -Djava.library.path=/usr/local/lib:/usr/lib64:/usr/lib
                   -Djava.util.logging.SimpleFormatter.format="$log_format" )

--- a/chronos.service
+++ b/chronos.service
@@ -4,6 +4,7 @@ After=network.target
 Wants=network.target
 
 [Service]
+EnvironmentFile=-/etc/sysconfig/chronos
 ExecStart=/usr/bin/chronos
 Restart=always
 RestartSec=20


### PR DESCRIPTION
This PR adds the fixes we've applied to the marathon wrapper to the chronos wrapper which at one point shared the same codebase.

Namely:
- being able to override JVM arguments by setting JAVA_OPTS in the environment
- only calling ulimit -n if run as root and current limit is less than 8192
- on systemd systems allow setting environment variables via /etc/sysconfig/chronos (RedHat recommended standard)
