### PR TITLE
Exclude zk_hosts and master options from zk file

### DIFF
--- a/bin/chronos-framework
+++ b/bin/chronos-framework
@@ -64,8 +64,14 @@ function load_options_and_log {
   # Default zk an master options
   if [[ -s /etc/mesos/zk ]]
   then
-    cmd+=( --zk_hosts "$(cut -d / -f 3 /etc/mesos/zk)"
-           --master "$(cat /etc/mesos/zk)" )
+    if [[ "${cmd[@]} $@" != *'--zk_hosts '* ]]
+    then
+      cmd+=( --zk_hosts "$(cut -d / -f 3 /etc/mesos/zk)" )
+    fi
+    if [[ "${cmd[@]} $@" != *'--master'* ]]
+    then
+      cmd+=( --master "$(cat /etc/mesos/zk)" )
+    fi
   fi
   logged chronos "${cmd[@]}" "$@"
 }


### PR DESCRIPTION
Don't import default options from /etc/mesos/zk
file if these options have already been given
in the command line or in the default file as
exported variables. It will prevent duplicate
options error and is done the same way in the
Marathon launcher script.