### PR TITLE
Setting log_format to the same as marathon-framework

### DIFF
--- a/bin/chronos-framework
+++ b/bin/chronos-framework
@@ -71,7 +71,7 @@ function load_options_and_log {
 }
 
 function run_jar {
-  local log_format='%2$s %5$s%6$s%n' # Class name, message, exception
+  local log_format='%2$s%5$s%6$s%n' # Class name, message, exception
 
   # if running as root and open file limit less than 8192 raise the limit
   [ $EUID -eq 0 -a $(ulimit -n) -lt 8192 ] && ulimit -n 8192


### PR DESCRIPTION
Making the log_format of both marathon and chronos consistent. See: https://github.com/mesosphere/marathon/blob/515f04b2b741a5c7dee36515c893b4cc267a9ed0/bin/marathon-framework#L95